### PR TITLE
refactor: 서버측 DTO 로직 수정에 따른 리뷰 추가 기능 수정

### DIFF
--- a/app/src/main/java/com/example/happy_dream_app/Service/ReviewService.java
+++ b/app/src/main/java/com/example/happy_dream_app/Service/ReviewService.java
@@ -7,10 +7,9 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 
 public interface ReviewService {
-    @POST("/reviews/{chargerId}/{userId}")
+    @POST("/reviews")
     Call<Void> addReview(
-            @Path("chargerId") int chargerId,
-            @Path("userId") int userId,
+            @retrofit2.http.Query("charger_id") int chargerId,
             @Body ReviewDTO reviewDTO
     );
 }

--- a/app/src/main/java/com/example/happy_dream_app/View/ReviewActivity.java
+++ b/app/src/main/java/com/example/happy_dream_app/View/ReviewActivity.java
@@ -59,14 +59,13 @@ public class ReviewActivity extends AppCompatActivity {
             return;
         }
 
-        // ReviewDTO 생성
-        ReviewDTO reviewDTO = new ReviewDTO(chargerId, userId, content, rating);
-
         // ReviewService 호출
         ReviewService reviewService = APIClient.getRetrofit().create(ReviewService.class);
 
-        // 경로 파라미터와 DTO 전달
-        Call<Void> call = reviewService.addReview(chargerId, userId, reviewDTO);
+        ReviewDTO review = new ReviewDTO(chargerId, userId, content, rating);
+
+        // 경로 파라미터와 리뷰 본문, 별점 전달
+        Call<Void> call = reviewService.addReview(chargerId, review);
 
         call.enqueue(new Callback<Void>() {
             @Override


### PR DESCRIPTION
- 엔드포인트를 변경 "/reviews/{chargerId}/{userId}" -> "/reviews"
- 요청 본문에 DTO를 넘겨주는 방식은 유지하되 URI 경로에 userId를 제거하고 userId를 DTO에 담는 방식으로 변경함.
- charger_id 또한 서버측의 요구에 맞게끔 쿼리 파라미터로 전달함